### PR TITLE
Upgrade npm dependencies, notably nan to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   },
   "main": "v8-debug",
   "dependencies": {
-    "node-pre-gyp": "^0.6.0",
-    "nan": "~1.5.0"
+    "node-pre-gyp": "^0.6.2",
+    "nan": "^1.6.2"
   },
   "bundledDependencies":["node-pre-gyp"],
   "devDependencies": {
-    "aws-sdk": "^2.0.0",
-    "mocha": "^1.20.1",
-    "chai": "^1.9.1"
+    "aws-sdk": "^2.1.8",
+    "mocha": "^2.1.0",
+    "chai": "^1.10.0"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",


### PR DESCRIPTION
This allows v8-debug to build under io.js and Node 0.12. However, v8-debug does not run under io.js! There is a problem where `processDebugRequest` is not getting called and the test hangs. This isn't a regression and this commit is in the right direction to getting v8-debug and node-inspector working on io.js -- it needs more investigation though.

The tests all pass under Node 0.10.36.