### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "type": "git",
     "url": "git://github.com/node-inspector/v8-debug.git"
   },
-  "license": {
-    "name": "BSD",
-    "url": "https://github.com/node-inspector/v8-debug/blob/master/LICENSE"
-  },
+  "license": "BSD-2-Clause",
   "binary": {
     "module_name": "debug",
     "module_path": "./build/{module_name}/v{version}/{node_abi}-{platform}-{arch}/",


### PR DESCRIPTION
Fixed `package.json` according to the npm guidelines.
- https://docs.npmjs.com/files/package.json#license

Uses the correct `BSD-2-Clause` SPDX license identifier.
- https://spdx.org/licenses/BSD-2-Clause.html