### PR TITLE
Fix #21: this.extendedProcessDebugJSONRequest_ is not a function

### DIFF
--- a/v8-debug.js
+++ b/v8-debug.js
@@ -93,7 +93,8 @@ var overrides = {
     }
   },
   processDebugRequest: function WRAPPED_BY_NODE_INSPECTOR(request) {
-    return this.extendedProcessDebugJSONRequest_(request)
+    return (this.extendedProcessDebugJSONRequest_
+      && this.extendedProcessDebugJSONRequest_(request))
       || this.processDebugJSONRequest(request);
   }
 };


### PR DESCRIPTION
See issue #21 and https://github.com/node-inspector/node-inspector/issues/756